### PR TITLE
Add methods to get a valid close waypoint for a given position or pose

### DIFF
--- a/grid_map_planner_lib/include/grid_map_planner_lib/grid_map_planner.h
+++ b/grid_map_planner_lib/include/grid_map_planner_lib/grid_map_planner.h
@@ -115,8 +115,38 @@ public:
   //bool doAlternativeExploration(const geometry_msgs::PoseStamped &start,std::vector<geometry_msgs::PoseStamped> &plan, std::vector<geometry_msgs::PoseStamped> &oldplan);
   //bool findFrontiersCloseToPath(std::vector<geometry_msgs::PoseStamped> &frontiers);
   //bool findInnerFrontier(std::vector<geometry_msgs::PoseStamped> &innerFrontier);
-  
 
+  /**
+   * Get the closest valid waypoint for a pose in the opposite direction of the pose's orientation.
+   * Example use case: POIs have the orientation of the sensor, so when looking for a waypoint from which this POI can
+   * be inspected, it needs to be searched in the opposite direction.
+   *
+   * @param pose The pose for which the waypoint is searched.
+   * @param min_distance_to_pose The minimum allowed distance to the pose.
+   * @param max_distance_to_pose The maximum allowed distance to the pose.
+   * @param min_distance_to_obstacle The minimum allowed distance to obstacles.
+   * @param close_waypoint The found waypoint.
+   *
+   * @return True if a valid waypoint was found, false otherwise.
+   */
+  bool getValidCloseWaypointForPose(const geometry_msgs::Pose& pose, double min_distance_to_pose,
+                                    double max_distance_to_pose, double min_distance_to_obstacle,
+                                    geometry_msgs::Pose& close_waypoint);
+
+  /**
+   * Get a close valid waypoint for a given position. Searches in all directions.
+   *
+   * @param position The position for which the waypoint is searched.
+   * @param min_distance_to_position The minimum allowed distance to the position.
+   * @param max_distance_to_position The maximum allowed distance to the position.
+   * @param min_distance_to_obstacle The minimum allowed distance to obstacles.
+   * @param close_waypoint The found waypoint.
+   *
+   * @return True if a valid waypoint was found, false otherwise.
+   */
+  bool getValidCloseWaypointForPosition(const geometry_msgs::Point& position, double min_distance_to_position,
+                                        double max_distance_to_position, double min_distance_to_obstacle,
+                                        geometry_msgs::Pose& close_waypoint);
 
   bool setMap(const grid_map::GridMap& map);
 

--- a/grid_map_planner_lib/include/grid_map_planner_lib/grid_map_utils.h
+++ b/grid_map_planner_lib/include/grid_map_planner_lib/grid_map_utils.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <geometry_msgs/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+namespace grid_map_utils
+{
+
+/**
+ * @brief Get the yaw angle from a quaternion.
+ */
+double getYawFromQuaternion(const geometry_msgs::Quaternion& quaternion)
+{
+  tf2::Quaternion tf_quat;
+  tf2::fromMsg(quaternion, tf_quat);
+  tf2::Matrix3x3 matrix(tf_quat);
+  double roll, pitch, yaw;
+  matrix.getRPY(roll, pitch, yaw);
+
+  return yaw;
+}
+
+/**
+ * @brief Compute the orientation in a 90 degree angle to the given vector from start to end.
+ * @return The orientation of the perpendicular line.
+ */
+geometry_msgs::Quaternion computePerpendicularOrientation(const geometry_msgs::Point& start,
+                                                          const geometry_msgs::Point& end)
+{
+  tf2::Vector3 start_v;
+  tf2::fromMsg(start, start_v);
+
+  tf2::Vector3 end_v;
+  tf2::fromMsg(end, end_v);
+
+  tf2::Vector3 diff = end_v - start_v;
+  diff.setZ(0.0);
+
+  tf2::Vector3 normal = diff.cross(tf2::Vector3(0, 0, 1));
+
+  tf2::Quaternion quat;
+  quat.setRPY(0, 0, atan2(normal.y(), normal.x()));
+
+  geometry_msgs::Quaternion orientation = tf2::toMsg(quat);
+
+  return orientation;
+}
+
+}  // namespace grid_map_utils

--- a/grid_map_planner_lib/src/grid_map_planner.cpp
+++ b/grid_map_planner_lib/src/grid_map_planner.cpp
@@ -27,6 +27,7 @@
 //=================================================================================================
 
 #include <grid_map_planner_lib/grid_map_planner.h>
+#include <grid_map_planner_lib/grid_map_utils.h>
 
 #include <grid_map_cv/grid_map_cv.hpp>
 #include <grid_map_proc/grid_map_transforms.h>
@@ -441,6 +442,182 @@ bool GridMapPlanner::makePlan(const std::vector<geometry_msgs::Pose>& starts, co
       plan_costs->at(i) = plan_cost;
     }
   }
+
+  return true;
+}
+
+bool GridMapPlanner::getValidCloseWaypointForPose(const geometry_msgs::Pose& pose, double min_distance_to_pose,
+                                                  double max_distance_to_pose, double min_distance_to_obstacle,
+                                                  geometry_msgs::Pose& close_waypoint)
+{
+  if (!this->planning_map_.exists("occupancy"))
+  {
+    ROS_ERROR("Tried to get close valid waypoint for pose, but map has no occupancy layer!");
+    return false;
+  }
+
+  double min_distance_to_obstacle_in_cells = min_distance_to_obstacle / this->planning_map_.getResolution();
+
+  grid_map::Position close_waypoint_gm;
+
+  // compute yaw from pose orientation to get direction of ray cast
+  double yaw = grid_map_utils::getYawFromQuaternion(pose.orientation);
+
+  // rotate by 180 degrees to get orientation pointing from the pose to the robot
+  // (POIs have the orientation following the line of sight from the robot to the POI)
+  yaw = yaw + M_PI;
+
+  double x_start = pose.position.x + min_distance_to_pose * std::cos(yaw);
+  double y_start = pose.position.y + min_distance_to_pose * std::sin(yaw);
+  grid_map::Position start_position(x_start, y_start);
+
+  double x_end = pose.position.x + max_distance_to_pose * std::cos(yaw);
+  double y_end = pose.position.y + max_distance_to_pose * std::sin(yaw);
+  grid_map::Position end_position(x_end, y_end);
+
+  if (!this->planning_map_.isInside(start_position))
+  {
+    ROS_WARN("Point in minimum distance to given pose already outside map! Cannot compute valid close waypoint.");
+    return false;
+  }
+
+  try
+  {
+    grid_map::LineIterator line_iterator = grid_map::LineIterator(this->planning_map_, start_position, end_position);
+
+    bool computed_distance_transform = false;
+    bool found_valid_point = false;
+    for (; !line_iterator.isPastEnd(); ++line_iterator)
+    {
+      if (this->planning_map_.at("occupancy", *line_iterator) < 50.0)
+      {
+        if (!computed_distance_transform)
+        {
+          if (!grid_map_transforms::addDistanceTransform(this->planning_map_, *line_iterator, obstacle_cells_,
+                                                         frontier_cells_))
+          {
+            ROS_WARN("Failed computing reachable obstacle cells!");
+            return false;
+          }
+          computed_distance_transform = true;
+        }
+
+        if (this->planning_map_.at("distance_transform", *line_iterator) > min_distance_to_obstacle_in_cells)
+        {
+          this->planning_map_.getPosition(*line_iterator, close_waypoint_gm);
+          found_valid_point = true;
+          break;
+        }
+      }
+    }
+
+    if (found_valid_point)
+    {
+      close_waypoint.position.x = close_waypoint_gm.x();
+      close_waypoint.position.y = close_waypoint_gm.y();
+      close_waypoint.position.z = 0;
+
+      close_waypoint.orientation =
+          grid_map_utils::computePerpendicularOrientation(close_waypoint.position, pose.position);
+
+      return true;
+    }
+
+    ROS_WARN("Unable to find valid waypoint on grid map for given start pose!");
+    return false;
+  }
+  catch (const std::exception& e)
+  {
+    ROS_ERROR_STREAM("Failed to create line iterator (exception "
+                     << e.what() << ")! Start pose: (" << start_position.x() << ", " << start_position.y()
+                     << "), end pose: (" << end_position.x() << ", " << end_position.y() << ")");
+    return false;
+  }
+}
+
+bool GridMapPlanner::getValidCloseWaypointForPosition(const geometry_msgs::Point& position,
+                                                      double min_distance_to_position, double max_distance_to_position,
+                                                      double min_distance_to_obstacle,
+                                                      geometry_msgs::Pose& close_waypoint)
+{
+  grid_map::Index start_index;
+
+  if (!this->planning_map_.getIndex(grid_map::Position(position.x, position.y), start_index))
+  {
+    ROS_WARN("Start coords outside map, unable to compute close waypoint!");
+    return false;
+  }
+
+  double min_dist_to_position_in_cells = min_distance_to_position / this->planning_map_.getResolution();
+  double max_dist_to_position_in_cells = max_distance_to_position / this->planning_map_.getResolution();
+  double min_dist_to_obstacle_in_cells = min_distance_to_obstacle / this->planning_map_.getResolution();
+
+  grid_map::Index close_free_index;
+  if (this->planning_map_.at("occupancy", start_index) > 50.0)
+  {
+    // define criteria for BFS search (find close free cell)
+    grid_map_path_planning::StoppingCriteria criteria_free_cell = [](const grid_map::GridMap& grid_map,
+                                                                     const grid_map::Index& start_index,
+                                                                     const grid_map::Index& current_index) {
+      return grid_map.at("occupancy", current_index) < 50.0;
+      ;
+    };
+
+    // use BFS to find closest free cell
+    if (!grid_map_path_planning::findCloseIndexMatchingCriteria(this->planning_map_, start_index, criteria_free_cell,
+                                                                close_free_index, max_dist_to_position_in_cells))
+    {
+      ROS_WARN("Unable to find free close waypoint!");
+      return false;
+    }
+  }
+  else
+  {
+    close_free_index = start_index;
+  }
+
+  if (!this->planning_map_.exists("distance_transform"))
+  {
+    if (!grid_map_transforms::addDistanceTransform(this->planning_map_, close_free_index, obstacle_cells_,
+                                                   frontier_cells_))
+    {
+      ROS_WARN("Failed computing distance transform!");
+      return false;
+    }
+  }
+
+  grid_map::Index waypoint_index;
+
+  // define criteria for BFS search (find close free cell which is min dist to pose and min dist to obstacles)
+  grid_map_path_planning::StoppingCriteria criteria =
+      [min_dist_to_position_in_cells, min_dist_to_obstacle_in_cells](
+          const grid_map::GridMap& grid_map, const grid_map::Index& start_index, const grid_map::Index& current_index) {
+        bool is_free = grid_map.at("occupancy", current_index) < 50.0;
+
+        double distance = (Eigen::Vector2d((current_index - start_index).cast<double>())).norm();
+        bool is_min_dist_to_pose = distance > min_dist_to_position_in_cells;
+
+        bool is_min_dist_to_obstacle = grid_map.at("distance_transform", current_index) > min_dist_to_obstacle_in_cells;
+
+        return is_free && is_min_dist_to_pose && is_min_dist_to_obstacle;
+      };
+
+  // use BFS to find closest free cell
+  if (!grid_map_path_planning::findCloseIndexMatchingCriteria(this->planning_map_, close_free_index, criteria,
+                                                              waypoint_index, max_dist_to_position_in_cells))
+  {
+    ROS_WARN("Unable to find free close waypoint!");
+    return false;
+  }
+
+  grid_map::Position waypoint_position;
+  this->planning_map_.getPosition(waypoint_index, waypoint_position);
+
+  close_waypoint.position.x = waypoint_position.x();
+  close_waypoint.position.y = waypoint_position.y();
+  close_waypoint.position.z = 0;
+
+  close_waypoint.orientation = grid_map_utils::computePerpendicularOrientation(close_waypoint.position, position);
 
   return true;
 }


### PR DESCRIPTION
Add two methods to get a valid close waypoint for a given position or a pose.

If only a position is given, the waypoint will be searched in all directions using a BFS.
If a pose is given, the waypoint will be searched in the opposite direction of the pose orientation (POIs have the orientation of the cameras, so for finding a waypoint from which they can be inspected it needs to be searched in the opposite direction).